### PR TITLE
README.md: add namespaces to snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ The usage is also very similar.
 Instantiate the client with your DSN:
 
 ```csharp
+using SharpRavenLight;
+
+...
+
 var ravenClient = new RavenClientLight("http://public:secret@example.com/project-id");
 ```
 
@@ -19,6 +23,11 @@ var ravenClient = new RavenClientLight("http://public:secret@example.com/project
 Call out to the client in your catch block:
 
 ```csharp
+using SharpRavenLight;
+using SharpRavenLight.Data;
+
+...
+
 try
 {
     int i2 = 0;


### PR DESCRIPTION
As they are not the same as the ones used in SharpRaven, it's a bit tricky to switch to SharpRavenLight without knowing this.