### PR TITLE
Upgrade 4.5.x to 4.6 to fix build with Visual Studio for Mac 7.3.2(.12)

### DIFF
--- a/src/SharpRavenLight/src/SharpRavenLight/SharpRavenLight.csproj
+++ b/src/SharpRavenLight/src/SharpRavenLight/SharpRavenLight.csproj
@@ -4,7 +4,7 @@
     <Description>SharpRaven Light is a lightweight .NET client for Sentry.</Description>
     <VersionPrefix>1.0.0-beta4</VersionPrefix>
     <Authors>Ricardo Alcantara</Authors>
-    <TargetFrameworks>net45;net451;netstandard1.5;netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard1.5;netstandard1.6;netstandard2.0</TargetFrameworks>
     <AssemblyName>SharpRavenLight</AssemblyName>
     <PackageId>SharpRavenLight</PackageId>
     <PackageTags>raven;sentry;logging</PackageTags>
@@ -26,7 +26,7 @@
     <DefineConstants>NET_CORE</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net451' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <DefineConstants>NET45</DefineConstants>
   </PropertyGroup>
 
@@ -34,13 +34,13 @@
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System.Net.Http" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' Or '$(TargetFramework)' == 'netstandard1.6' ">
+  <ItemGroup>
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />
   </ItemGroup>

--- a/src/SharpRavenLight/test/SharpRavenLight.ConsoleTest/SharpRavenLight.ConsoleTest.csproj
+++ b/src/SharpRavenLight/test/SharpRavenLight.ConsoleTest/SharpRavenLight.ConsoleTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp1.0</TargetFrameworks>
     <AssemblyName>SharpRavenLight.ConsoleTest</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>SharpRavenLight.ConsoleTest</PackageId>
@@ -16,7 +16,7 @@
     <ProjectReference Include="..\..\src\SharpRavenLight\SharpRavenLight.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>


### PR DESCRIPTION
As per discussion in #11, somehow the projects in the
solution don't load anymore in Visual Studio 15.5.0, and
there are no logs whatsoever to know what's wrong.

However, in Visual Studio for Mac, at least the projects
load but the build fails with what it seems to be a VS bug:
Package System.Diagnostics.StackTrace 4.3.0 is not compatible with net451
(I say this might be a bug because the reference to this nuget
package has this attribute: Condition=" '$(TargetFramework)' == 'net451' )

Nevertheless, this nuget package supports .NET 4.6 so if we
make SharpRavenLight target this .NET Framework instead of
4.5/4.5.1 as a workaround, the build error goes away.